### PR TITLE
Disable Next.js telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
+    "build": "NEXT_TELEMETRY_DISABLED=1 next build",
+    "start": "NEXT_TELEMETRY_DISABLED=1 next start",
     "lint": "next lint",
     "fmt": "prettier --write .",
     "prepare": "husky install"


### PR DESCRIPTION
## Summary
- disable Next.js telemetry using an env var

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(fails: connect EHOSTUNREACH 172.26.0.3:8080)*
