### PR TITLE
Fix static build deployment

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
   workflow_dispatch:
 
 permissions:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  output: 'export',
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "NEXT_TELEMETRY_DISABLED=1 next dev",
-    "build": "NEXT_TELEMETRY_DISABLED=1 next build",
+    "build": "NEXT_TELEMETRY_DISABLED=1 next build && NEXT_TELEMETRY_DISABLED=1 next export -o dist",
+    "export": "NEXT_TELEMETRY_DISABLED=1 next export -o dist",
     "start": "NEXT_TELEMETRY_DISABLED=1 next start",
     "lint": "next lint",
     "fmt": "prettier --write .",


### PR DESCRIPTION
## Summary
- export static site via Next.js
- update npm build script
- deploy built static site
- remove unused workflow paths filter

## Testing
- `npm run lint`
- `npm run build` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*